### PR TITLE
docs: Add notes on limits for 'titles' parameter

### DIFF
--- a/shortdesc-api/README.md
+++ b/shortdesc-api/README.md
@@ -27,6 +27,10 @@ The titles of MediaWiki pages. The title is case sensitive.
 For the example, https://en.wikipedia.org/wiki/Abraham_Lincoln,
 the title would be `Abraham_Lincoln`.
 
+**Note:** The API reflects the same limit on the maximum number of `titles`
+values in a single request allowed by the parameter of the same name for the
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Query#API_documentation), i.e. maximum is 50 values.
+
 ### Response schema
 
 The API response follows this schema:

--- a/shortdesc-api/docs/considerations.md
+++ b/shortdesc-api/docs/considerations.md
@@ -65,6 +65,12 @@ that was leveraged. Seems to also align with guidance on how to write a
 of the MediaWiki API to also use query parameters itself. Following 
 same pattern could be familiar for users hitting APIs for both MediaWiki and shortdesc. 
 
+- Given that shortdesc-api makes use of the [MediaWiki API](https://www.mediawiki.org/wiki/API:Query#API_documentation),
+decision was made to communicate the same limit with the `titles` parameter in
+the schema docs, i.e. the maximum number of `titles` values in a single request
+allowed is 50 values. This is the same limit with the `titles` parameter
+in the MediaWiki API.
+
 - Redirects for a page title are possible as mentioned in 
 [Resolving redirects](https://www.mediawiki.org/wiki/API:Query#Resolving_redirects). 
 However: 


### PR DESCRIPTION
Add notes in user-facing docs and in design considerations. Parameter limits reflect limits in the MediaWiki API.